### PR TITLE
Fixed TPtoME and GodMode starvation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,13 @@ If this step is not done, you will not be able to use "Teleport" OR "Teleport to
 ***Option #2)*** Open your ***init.sqf*** and replace the above line with this:
 
 ~~~~java
-AT_all = ["111111111","222222222","333333333"];
-if (not ((getPlayerUID player) in AT_all)) then {
-    [] execVM "\z\addons\dayz_code\system\antihack.sqf";
-};
+	if (not ((getPlayerUID player) in AdminList)) then 
+	{
+		if (not ((getPlayerUID player) in tempList)) then
+		{
+			[] execVM "\z\addons\dayz_code\system\antihack.sqf";
+		};
+	};
 ~~~~
     
 ...then replace the above numbers with PIDs of players with whom you wish to have the antihack disabled.

--- a/admintools/tools/TPtoME.sqf
+++ b/admintools/tools/TPtoME.sqf
@@ -19,16 +19,27 @@ while {pselect5 == ""} do
 	WaitUntil {pselect5 != "" or snext};	
 	snext = false;
 };
+
+tempList = nil;
+
 if (pselect5 != "exit") then
 {
 	_name = pselect5;
+	
 	{
 		if(name _x == _name) then
 		{
+			_tempException = getPlayerUID _x;
+			tempList = [
+				"_tempException"
+			];
 			hint format ["Teleporting %1", _name];
 			_x attachTo [vehicle player, [2, 2, 0]];
 			sleep 0.25;
 			detach _x;
+			_tempException = nil;
+			sleep 0.5;
+
 		};
 	} forEach entities "CAManBase";
 };

--- a/admintools/tools/malplayerGM.sqf
+++ b/admintools/tools/malplayerGM.sqf
@@ -11,6 +11,7 @@ if (malpgm == 0) then
 	malpgm = 1;
     cutText ["Player and Zombie God Mode - ON", "PLAIN"];
 	player_zombieCheck = {};
+	fnc_usec_damageHandler = {};
 	(vehicle player) removeAllEventHandlers "handleDamage";
 	(vehicle player) addEventHandler ["handleDamage", { false }];	
 	(vehicle player) allowDamage false;
@@ -37,10 +38,6 @@ if (malpgm == 0) then
 	player setHit ['legs',0];
 	player setVariable ['hit_legs',0,false];
 	player setVariable['medForceUpdate',true,true];
-	
-	while {malpgm == 1} do
-	{
-	};
 }
 	
 else


### PR DESCRIPTION
TPtoMe now works for ALL players IF and only if you follow the NEW
ReadMe instructions for setting up the exception.
Player starvation/thirst damage for GodMode is now removed.
