### PR TITLE
Changed Varible Call in Revive Repair(Perm) Vehicle sqf files

### DIFF
--- a/admintools/tools/PointToRepairPERM.sqf
+++ b/admintools/tools/PointToRepairPERM.sqf
@@ -12,7 +12,7 @@ _player = player;
 
     if (_damage > 0) then {
 		_selection = getText(configFile >> "cfgVehicles" >> _type >> "HitPoints" >> _x >> "name");
-		[_vehicle,_selection,0] call object_setFixServer;
+		[_vehicle,_selection,0] call fnc_veh_setFixServer;
 	};
 } count _hitpoints;
 

--- a/admintools/tools/PointToReviveVeh.sqf
+++ b/admintools/tools/PointToReviveVeh.sqf
@@ -13,7 +13,7 @@ for "_i" from 1 to 10 do {
 
 		if (_damage > 0) then {
 			_selection = getText(configFile >> "cfgVehicles" >> _type >> "HitPoints" >> _x >> "name");
-			[_vehicle,_selection,0] call object_setFixServer;
+			[_vehicle,_selection,0] call fnc_veh_setFixServer;
 		};
 	} count _hitpoints;
 


### PR DESCRIPTION
Updated Varible call in

PointToReviveVeh.sqf
and
PointToRepairPERM.sqf

Per change documentation for Epoch 1.0.6.1
**object_setFixServer** --> **fnc_veh_setFixServer**

Hopefully this will prevent unwanted client RPT spam when used.

